### PR TITLE
chore: update to 18.2.0

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -85,7 +85,7 @@ jobs:
       with:
         api-level: 29
         target: playstore
-        script: npm run test:android -- --sdkVersion 12.1.0.v20221229113413
+        script: npm run test:android -- --sdkVersion 12.2.1.GA
         disable-animations: false # defaulting to true, the commands sent to emulator to do this sometimes run too quickly after boot and cause "adb: device offline" failures
 
     - name: Show summary of ccache configuration and statistics counters

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,7 +60,7 @@ jobs:
     - run: npm i -g titanium
       name: Install Titanium CLI
 
-    - run: ti sdk install --branch master 12.2.1.GA --force
+    - run: ti sdk install 12.2.1.GA
       name: Install SDK 12.2.1
 
     - name: Set up Homebrew

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,8 +60,8 @@ jobs:
     - run: npm i -g titanium
       name: Install Titanium CLI
 
-    - run: ti sdk install --branch master 12.1.0.v20221229113413 --force
-      name: Install SDK 12.1.0
+    - run: ti sdk install --branch master 12.2.1.GA --force
+      name: Install SDK 12.2.1
 
     - name: Set up Homebrew
       id: set-up-homebrew

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
 	// Needed to check for Google Play Services availability on device.
-	implementation 'com.google.android.gms:play-services-base:18.1.0'
+	implementation 'com.google.android.gms:play-services-base:18.2.0'
 
 	// App devs expect adding "ti.playservices" will enable "Fused Location" support to "Ti.Gelocation" APIs.
 	// So, we must add this library to support it, even though this module doesn't use this library at all.

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 18.2.0
+version: 18.2.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: Titanium Google Play Services module.


### PR DESCRIPTION
Update play-services-base to 18.2.0

Changelog: https://developers.google.com/android/guides/releases#february_15_2023
> Added a new API in [GoogleApiAvailability](https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability) that enables developers to display a DialogFragment for an error code returned by [isGooglePlayServicesAvailable](https://developers.google.com/android/reference/com/google/android/gms/common/GoogleApiAvailability#isGooglePlayServicesAvailable(android.content.Context)) using the ActivityResultContract pattern.

(it's not implemented)

**NOTE:** 
I would like to keep the version number to the same as play-services-base. Makes it easier to see which version is included. Since we are using 18.2.0 already I'll set this to 18.2.1 so that we stay in 18.2.x

[ti.playservices-android-18.2.1.zip](https://github.com/tidev/ti.playservices/files/13306626/ti.playservices-android-18.2.1.zip)
